### PR TITLE
Use filtered clone/fetch for checks

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -56,7 +56,7 @@ else
     branchflag="--branch $branch"
   fi
 
-  git clone --bare --single-branch $uri $branchflag $destination $tagflag
+  git clone --bare --filter=blob:none --single-branch $uri $branchflag $destination $tagflag
   cd $destination
   # bare clones don't configure the refspec
   if [ -n "$branch" ]; then

--- a/assets/check
+++ b/assets/check
@@ -48,16 +48,20 @@ export GIT_LFS_SKIP_SMUDGE=1
 
 if [ -d $destination ]; then
   cd $destination
-  git fetch $tagflag -f
-  git reset --hard FETCH_HEAD
+  git fetch origin $tagflag $branch -f
+  git reset --soft FETCH_HEAD
 else
   branchflag=""
   if [ -n "$branch" ]; then
     branchflag="--branch $branch"
   fi
 
-  git clone --single-branch $uri $branchflag $destination $tagflag
+  git clone --bare --single-branch $uri $branchflag $destination $tagflag
   cd $destination
+  # bare clones don't configure the refspec
+  if [ -n "$branch" ]; then
+    git remote set-branches --add origin $branch
+  fi
 fi
 
 if [ -n "$ref" ] && git cat-file -e "$ref"; then


### PR DESCRIPTION
YMMV, but with a large monorepo we saw:
 - 99% reduction in network traffic between the concourse workers and GHE server
 - 90% reduction in CPU usage on the server during clone/fetch